### PR TITLE
Sanitize file paths

### DIFF
--- a/pithos/pithos.py
+++ b/pithos/pithos.py
@@ -27,6 +27,7 @@ import tempfile
 import urllib.error
 import urllib.parse
 import urllib.request
+import unicodedata
 from enum import Enum
 from mutagen.id3 import ID3, TRCK, TIT2, TALB, TPE1, APIC, TCON
 

--- a/pithos/pithos.py
+++ b/pithos/pithos.py
@@ -216,10 +216,8 @@ class CellRendererAlbumArt(Gtk.CellRenderer):
 
 
 def clean_name(s):
-    # for windows you can do this:
-    #valid_chars = "-_.() %s%s" % (string.ascii_letters, string.digits)
-    # return ''.join(c if c in valid_chars else '-' for c in s.strip())
-    return s.strip().replace("/", "-")
+    valid_chars = "-_.,()[]~!@#$^&=+ %s%s" % (string.ascii_letters, string.digits)
+    return ''.join(c if c in valid_chars else '-' for c in unicodedata.normalize('NFKD', s.strip()).encode('ASCII', 'ignore'))
 
 
 @GtkTemplate(ui='/io/github/Pithos/ui/PithosWindow.ui')
@@ -827,7 +825,7 @@ class PithosWindow(Gtk.ApplicationWindow):
         #self.buffer_percent = 100
         # set output file
 
-        self.outfolder = "%s/%s/%s/" % (self.save_dir(), self.current_song.artist, self.current_song.album)
+        self.outfolder = "%s/%s/%s/" % (self.save_dir(), clean_name(self.current_song.artist), clean_name(self.current_song.album))
         if not os.path.exists(self.outfolder):
             os.makedirs(self.outfolder)
         self.fs.set_property("location", f"{self.outfolder}")
@@ -1177,9 +1175,9 @@ class PithosWindow(Gtk.ApplicationWindow):
         # move the partial into completed
 
         if self.current_song.rating == RATE_LOVE:
-            newlocation = "%s.mp3" % f"{self.outfolder}{self.current_song.title}"
+            newlocation = "%s.mp3" % f"{self.outfolder}{clean_name(self.current_song.title)}"
         else:
-            newlocation = "%s.mp3" % f"{self.outfolder}{self.current_song.title}"
+            newlocation = "%s.mp3" % f"{self.outfolder}{clean_name(self.current_song.title)}"
             logging.warning(f"{self.outfolder}")
         shutil.move(self.fs.get_property("location"), newlocation)
         logging.warning(f"{newlocation}")

--- a/pithos/pithos.py
+++ b/pithos/pithos.py
@@ -217,7 +217,7 @@ class CellRendererAlbumArt(Gtk.CellRenderer):
 
 
 def clean_name(s):
-    valid_chars = "-_.,()[]~!@#$^&=+ %s%s" % (string.ascii_letters, string.digits)
+    valid_chars = "-_.,'()[]~!@#$^&=+ %s%s" % (string.ascii_letters, string.digits)
     return ''.join(c if c in valid_chars else '-' for c in unicodedata.normalize('NFKD', s.strip()).encode('ASCII', 'ignore').decode('ascii'))
 
 

--- a/pithos/pithos.py
+++ b/pithos/pithos.py
@@ -218,7 +218,7 @@ class CellRendererAlbumArt(Gtk.CellRenderer):
 
 def clean_name(s):
     valid_chars = "-_.,()[]~!@#$^&=+ %s%s" % (string.ascii_letters, string.digits)
-    return ''.join(c if c in valid_chars else '-' for c in unicodedata.normalize('NFKD', s.strip()).encode('ASCII', 'ignore'))
+    return ''.join(c if c in valid_chars else '-' for c in unicodedata.normalize('NFKD', s.strip()).encode('ASCII', 'ignore').decode('ascii'))
 
 
 @GtkTemplate(ui='/io/github/Pithos/ui/PithosWindow.ui')


### PR DESCRIPTION
Use the existing `clean_name` function to sanitize file paths generated from artist/album/song names.
Update the function to strip out more characters while still being more permissive than the original "windows" version in the comments.
Should limit filenames to NTFS-valid names even on linux so the saved files can be copied between systems.

Fixes longstanding bug where saving would fail and playback would halt any time a song containing forbidden characters played, and make directories in error if the forbidden character was a /.